### PR TITLE
fix: Bar choice while priority is low

### DIFF
--- a/code/modules/client/preferences/bar_choice.dm
+++ b/code/modules/client/preferences/bar_choice.dm
@@ -15,8 +15,8 @@
 	if (!..(preferences))
 		return FALSE
 	
-	// Job needs to be medium or high for the preference to show up
-	return preferences.job_preferences["Bartender"] >= JP_MEDIUM
+	// Job needs to be low or high for the preference to show up
+	return preferences.job_preferences["Bartender"] >= JP_LOW
 
 /datum/preference/choiced/bar_choice/apply_to_human(mob/living/carbon/human/target, value)
 	return


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

<!-- Снижен приоритет на роль бармена для выбора бара с medium до low, чтобы даже если выпал бармен на лоу, заспавнился тот бар, который игрок захочет.-->

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- -Снижен приоритет на роль бармена для выбора бара с medium до low. -->

:cl:  
tweak: tweaked a few things  
/:cl:
